### PR TITLE
Proper handling of icon "helpers" like fa-lg, fa-fw, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Metalsmith Icons
 
-A [Metalsmith](http://metalsmith.io) plugin for automatically building font icon sets 
+A [Metalsmith](http://metalsmith.io) plugin for automatically building font icon sets
 
 ## Overview
 
@@ -45,7 +45,7 @@ Metalsmith(__dirname)
 
 ### Options
 
-#### Default options: 
+#### Default options:
 
 ```js
 var defaults = {
@@ -61,7 +61,14 @@ var defaults = {
     substitutions: loadSubstitutions(), // loads substitutions object from substitutions.yml
     cache: './.icon_cache',
     fontDir: 'font',
-    CSSDir: 'styles'
+    CSSDir: 'styles',
+    icon_helpers: {
+      fontawesome: ["fa-lg fa-2x fa-3x fa-4x fa-5x",
+         "fa-fw fa-ul fa-li fa-border fa-pull-right fa-pull-left",
+         "fa-spin fa-pulse fa-rotate-90 fa-rotate-180 fa-rotate-270",
+         "fa-flip-horizontal fa-flip-vertical fa-stack fa-stack-1x",
+         "fa-stack-2x fa-inverse"].join(" ")
+    }
 };
 ```
 
@@ -127,6 +134,9 @@ If you find a substitution, it would be amazing if you could [submit a pull requ
 	}
 }))
 ```
+#### `icon_helpers` [Object]
+
+These are css classes that begin with the prefix of the font set, but are not themselves icons.  They should be handled differently.
 
 ## Caveats
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -291,14 +291,7 @@ function getZipFiles(zipFile,config){
         // if we find a css file, add it to our CSS directory
         if(minimatch(zipEntry.entryName,'**/css/'+config.fontello.name+'.css')){
             var file = config.CSSDir+'/'+path.basename(zipEntry.entryName);
-            // if we're using the standard 'font' dir for fonts, just add the CSS files
-            if(config.fontDir === 'font'){
-                zipFiles[file] = {contents:zipEntry.getData()};
-            } else {
-                var contents = zipEntry.getData().toString();
-                contents = replaceall('/font/','/'+config.fontDir+'/',contents);
-                zipFiles[file] = {contents:contents}
-            }
+            zipFiles[file] = {contents:zipEntry.getData()};
         }
     })
     return zipFiles;

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,14 @@ var equal = require('deep-equal');
         cache: './.icon_cache',
         fontDir: 'font',
         CSSDir: 'styles',
-        customIcons: false
+        customIcons: false,
+        icon_helpers: {
+          fontawesome: ["fa-lg fa-2x fa-3x fa-4x fa-5x",
+            "fa-fw fa-ul fa-li fa-border fa-pull-right fa-pull-left",
+            "fa-spin fa-pulse fa-rotate-90 fa-rotate-180 fa-rotate-270",
+            "fa-flip-horizontal fa-flip-vertical fa-stack fa-stack-1x",
+            "fa-stack-2x fa-inverse"].join(" ")
+        }
     };
 
 
@@ -46,7 +53,7 @@ var plugin = function (config) {
     // main metalsmith plugin
     return function (files, metalsmith, done){
         if(sets){
-            
+
             // load icon sets
             Object.keys(sets).forEach(function(set){
                 var setName = sets[set];
@@ -63,14 +70,25 @@ var plugin = function (config) {
                     Object.keys(sets).forEach(function(set){
                         //
                         var setName = sets[set];
+                        var all_icon_helpers = config["icon_helpers"] || {};
+                        var icon_helpers = all_icon_helpers[setName] || [];
                         $('.'+set).each(function(){
-                            var icon = $(this).attr('class').replace(set,'').replace(set+'-','').trim()
-                            include[setName].push( icon );
-                            // update our html to match
-                            $(this).removeClass(set)
-                                   .removeClass(set+'-'+icon)
-                                   .addClass(config.fontello.css_prefix_text.replace('-',''))
-                                   .addClass(config.fontello.css_prefix_text+icon)
+                            var self = $(this);
+                            var classes = self.attr('class').split(' ').filter(function(s) { return s; });
+                            var icon_classes = classes.filter(function(s) {
+                              return s.startsWith(set) && icon_helpers.indexOf(s) == -1;
+                            });
+                            // var other_classes = classes.filter(function(s) { return !s.startsWith(set); });
+                            var icon_bases = icon_classes.map(function(c) {
+                              return c.replace(set + '-', '').replace(set, '').trim();
+                            }).filter(function(s) { return s; });
+                            icon_bases.forEach(function(icon) {
+                              include[setName].push(icon);
+                              self.removeClass(set)
+                                .removeClass(set + '-' + icon)
+                                .addClass(config.fontello.css_prefix_text.replace('-', ''))
+                                .addClass(config.fontello.css_prefix_text + icon);
+                            });
                         });
                     });
                     files[file].contents = $.html();
@@ -113,13 +131,13 @@ var plugin = function (config) {
                 }
 
 
-                // add custom icons if we need them 
+                // add custom icons if we need them
                 if(config.customIcons){
                     var customIcons = JSON.parse(files[config.customIcons].contents.toString().trim());
                     delete files[config.customIcons];
                     glyphs = glyphs.concat(customIcons)
                 }
-                
+
                 // add these glyphs to the main config.fontello object
                 glyphs.forEach(function(glyph){
                     delete glyph.search;
@@ -129,7 +147,7 @@ var plugin = function (config) {
                 })
             });
 
-            
+
             // work out if we have a cached version of this icon set
             var cacheFile = false;
             if(config.cache){
@@ -188,7 +206,7 @@ var plugin = function (config) {
                     console.error(error);
                 });
             }
-            
+
         }
     }
 
@@ -205,7 +223,7 @@ function loadSubstitutions (){
 // Makes the main API request to the fontello server
 function makeAPIRequest (jsonFile){
     return new Promise(function(resolve,reject){
-        
+
         // build options for request
         var fontelloURL = 'http://fontello.com/';
         var requestOptions = {
@@ -247,9 +265,9 @@ function makeAPIRequest (jsonFile){
                 .on('end',function(){
                     // add all the ZIP file chunks to a new Buffer
                     var buf = new Buffer(zipDataLen);
-                    for (var i=0, len = zipData.length, pos = 0; i < len; i++) { 
-                        zipData[i].copy(buf, pos); 
-                        pos += zipData[i].length; 
+                    for (var i=0, len = zipData.length, pos = 0; i < len; i++) {
+                        zipData[i].copy(buf, pos);
+                        pos += zipData[i].length;
                     }
                     resolve(buf);
                 });
@@ -285,7 +303,7 @@ function getZipFiles(zipFile,config){
         }
     })
     return zipFiles;
-    
+
 }
 
 function cacheZipFile (zipFile,jsonFile,config){

--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,6 @@ var plugin = function (config) {
                             var icon_classes = classes.filter(function(s) {
                               return s.startsWith(set) && icon_helpers.indexOf(s) == -1;
                             });
-                            // var other_classes = classes.filter(function(s) { return !s.startsWith(set); });
                             var icon_bases = icon_classes.map(function(c) {
                               return c.replace(set + '-', '').replace(set, '').trim();
                             }).filter(function(s) { return s; });


### PR DESCRIPTION
Fontawesome has lots of "helper" classes that, unfortunately, also start with "fa-".  This is a patch to ignore those when looking up icons.

Cool project!  Thanks for the work!
