### PR TITLE
fontDir handling is broken

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -274,14 +274,7 @@ function getZipFiles(zipFile,config){
         // if we find a css file, add it to our CSS directory
         if(minimatch(zipEntry.entryName,'**/css/'+config.fontello.name+'.css')){
             var file = config.CSSDir+'/'+path.basename(zipEntry.entryName);
-            // if we're using the standard 'font' dir for fonts, just add the CSS files
-            if(config.fontDir === 'font'){
-                zipFiles[file] = {contents:zipEntry.getData()};
-            } else {
-                var contents = zipEntry.getData().toString();
-                contents = replaceall('/font/','/'+config.fontDir+'/',contents);
-                zipFiles[file] = {contents:contents}
-            }
+            zipFiles[file] = {contents:zipEntry.getData()};
         }
     })
     return zipFiles;


### PR DESCRIPTION
Unfortunately it's very difficult to tell where the fontello urls will point to in the css file, and so just replacing them with some version of fontDir doesn't work.  What works better is to have a directory named "font" as  a subdirectory of the same directory containing your "css" directory; perhaps you should just recommend people do that.  Otherwise the logic for figuring out what to change where will be very difficult, I think.
